### PR TITLE
Add bottom navigation for mobile-friendly tab switching

### DIFF
--- a/index.html
+++ b/index.html
@@ -231,7 +231,63 @@
       .app-shell {
         width: min(1180px, calc(100% - 32px));
         margin: 0 auto;
-        padding: 28px 0 48px;
+        padding: 28px 0 100px;
+      }
+
+      /* Bottom Navigation */
+      .bottom-nav {
+        position: fixed;
+        bottom: 0;
+        left: 0;
+        right: 0;
+        display: flex;
+        justify-content: space-around;
+        align-items: center;
+        background: var(--surface-strong);
+        border-top: 1px solid var(--border);
+        backdrop-filter: blur(20px);
+        -webkit-backdrop-filter: blur(20px);
+        padding: 6px 0 calc(6px + env(safe-area-inset-bottom, 0));
+        z-index: 1000;
+        box-shadow: 0 -2px 20px rgba(0, 0, 0, 0.06);
+      }
+
+      .bottom-nav-item {
+        display: flex;
+        flex-direction: column;
+        align-items: center;
+        gap: 2px;
+        padding: 6px 12px;
+        border: none;
+        background: none;
+        color: var(--muted);
+        font-size: 10px;
+        font-weight: 500;
+        cursor: pointer;
+        transition: color 0.2s ease, transform 0.15s ease;
+        -webkit-tap-highlight-color: transparent;
+        position: relative;
+        min-width: 56px;
+      }
+
+      .bottom-nav-item svg {
+        width: 22px;
+        height: 22px;
+        stroke-width: 1.8;
+        transition: transform 0.2s ease;
+      }
+
+      .bottom-nav-item.active {
+        color: var(--accent);
+        font-weight: 700;
+      }
+
+      .bottom-nav-item.active svg {
+        transform: scale(1.1);
+      }
+
+      .bottom-nav-item:active {
+        transform: scale(0.92);
       }
 
       .hero {
@@ -398,7 +454,7 @@
       }
 
       .content-grid {
-        grid-template-columns: minmax(0, 1.2fr) minmax(320px, 0.8fr);
+        grid-template-columns: 1fr;
         gap: 18px;
         margin-top: 18px;
       }
@@ -3574,7 +3630,7 @@
         .tab-row, .export-row, .export-grid, .data-actions,
         .google-actions, .record-delete, .quick-section,
         .voice-box, .photo-box, .note-tags-row, .date-shortcuts,
-        .record-search, .record-date-range, .ad-slot,
+        .record-search, .record-date-range, .ad-slot, .bottom-nav,
         [data-action="save-record"], [data-action="save-profile"],
         [data-action="save-settings"], [data-action="toggle-records"] {
           display: none !important;

--- a/src/app.js
+++ b/src/app.js
@@ -133,6 +133,7 @@ let recordSearchQuery = "";
 let recordDateFrom = "";
 let recordDateTo = "";
 let searchDebounceTimer = null;
+let activeTab = "home";
 
 // Initialize quick weight from last record
 {
@@ -359,7 +360,7 @@ function render() {
 
   app.innerHTML = `
     <main class="app-shell">
-      <section class="hero">
+      <section class="hero" ${activeTab !== "home" ? 'style="display:none"' : ""}>
         <div class="hero-top">
           <div>
             <div class="eyebrow">${t("status.ready")}</div>
@@ -447,7 +448,7 @@ function render() {
       </section>
 
       <div class="content-grid">
-        <div class="column">
+        <div class="column" data-tab="home" ${activeTab !== "home" ? 'style="display:none"' : ""}>
           <section class="panel">
             <div class="section-header">
               <div>
@@ -607,7 +608,9 @@ function render() {
               ${lastUndoState ? `<button type="button" class="undo-btn" data-action="undo">${t("undo.button")}</button>` : ""}
             </div>
           </section>
+        </div>
 
+        <div class="column" data-tab="graph" ${activeTab !== "graph" ? 'style="display:none"' : ""}>
           <section class="panel">
             <div class="section-header">
               <div>
@@ -713,7 +716,9 @@ function render() {
             </div>
             ` : ""}
           </section>
+        </div>
 
+        <div class="column" data-tab="calendar" ${activeTab !== "calendar" ? 'style="display:none"' : ""}>
           <!-- Monthly Stats Panel -->
           ${renderMonthlyStats()}
 
@@ -727,7 +732,9 @@ function render() {
             </div>
             ${renderCalendar()}
           </section>
+        </div>
 
+        <div class="column" data-tab="search" ${activeTab !== "search" ? 'style="display:none"' : ""}>
           <!-- Records List Panel -->
           <section class="panel records-panel">
             <div class="section-header">
@@ -773,7 +780,7 @@ function render() {
           </section>
         </div>
 
-        <div class="column">
+        <div class="column" data-tab="settings" ${activeTab !== "settings" ? 'style="display:none"' : ""}>
           <section class="panel">
             <div class="section-header">
               <div>
@@ -953,6 +960,28 @@ function render() {
         </div>
       </div>
     </main>
+    <nav class="bottom-nav" role="navigation" aria-label="メインナビゲーション">
+      <button type="button" class="bottom-nav-item ${activeTab === "home" ? "active" : ""}" data-nav="home">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M3 9l9-7 9 7v11a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2z"/><polyline points="9 22 9 12 15 12 15 22"/></svg>
+        <span>${t("nav.home")}</span>
+      </button>
+      <button type="button" class="bottom-nav-item ${activeTab === "search" ? "active" : ""}" data-nav="search">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="11" cy="11" r="8"/><line x1="21" y1="21" x2="16.65" y2="16.65"/></svg>
+        <span>${t("nav.search")}</span>
+      </button>
+      <button type="button" class="bottom-nav-item ${activeTab === "calendar" ? "active" : ""}" data-nav="calendar">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
+        <span>${t("nav.calendar")}</span>
+      </button>
+      <button type="button" class="bottom-nav-item ${activeTab === "graph" ? "active" : ""}" data-nav="graph">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="18" y1="20" x2="18" y2="10"/><line x1="12" y1="20" x2="12" y2="4"/><line x1="6" y1="20" x2="6" y2="14"/></svg>
+        <span>${t("nav.graph")}</span>
+      </button>
+      <button type="button" class="bottom-nav-item ${activeTab === "settings" ? "active" : ""}" data-nav="settings">
+        <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 0 0 .33 1.82l.06.06a2 2 0 0 1 0 2.83 2 2 0 0 1-2.83 0l-.06-.06a1.65 1.65 0 0 0-1.82-.33 1.65 1.65 0 0 0-1 1.51V21a2 2 0 0 1-2 2 2 2 0 0 1-2-2v-.09A1.65 1.65 0 0 0 9 19.4a1.65 1.65 0 0 0-1.82.33l-.06.06a2 2 0 0 1-2.83 0 2 2 0 0 1 0-2.83l.06-.06A1.65 1.65 0 0 0 4.68 15a1.65 1.65 0 0 0-1.51-1H3a2 2 0 0 1-2-2 2 2 0 0 1 2-2h.09A1.65 1.65 0 0 0 4.6 9a1.65 1.65 0 0 0-.33-1.82l-.06-.06a2 2 0 0 1 0-2.83 2 2 0 0 1 2.83 0l.06.06A1.65 1.65 0 0 0 9 4.68a1.65 1.65 0 0 0 1-1.51V3a2 2 0 0 1 2-2 2 2 0 0 1 2 2v.09a1.65 1.65 0 0 0 1 1.51 1.65 1.65 0 0 0 1.82-.33l.06-.06a2 2 0 0 1 2.83 0 2 2 0 0 1 0 2.83l-.06.06A1.65 1.65 0 0 0 19.4 9a1.65 1.65 0 0 0 1.51 1H21a2 2 0 0 1 2 2 2 2 0 0 1-2 2h-.09a1.65 1.65 0 0 0-1.51 1z"/></svg>
+        <span>${t("nav.settings")}</span>
+      </button>
+    </nav>
     ${rainbowVisible ? `
     <div class="rainbow-overlay" id="rainbowOverlay" role="alert" aria-live="assertive">
       <div class="confetti-container" id="confettiContainer"></div>
@@ -1870,6 +1899,15 @@ function renderPickerDecOptions(selected) {
 }
 
 function bindEvents() {
+  // Bottom navigation
+  app.querySelectorAll("[data-nav]").forEach((button) => {
+    button.addEventListener("click", () => {
+      activeTab = button.dataset.nav;
+      render();
+      window.scrollTo(0, 0);
+    });
+  });
+
   app.querySelectorAll("[data-mode]").forEach((button) => {
     button.addEventListener("click", () => {
       activeEntryMode = button.dataset.mode;

--- a/src/i18n.js
+++ b/src/i18n.js
@@ -550,6 +550,11 @@ export const translations = {
     "streakReward.master": "マスター",
     "streakReward.legend": "レジェンド",
     "streakReward.hint": "毎日記録して次のバッジを目指そう！",
+    "nav.home": "ホーム",
+    "nav.search": "検索",
+    "nav.calendar": "カレンダー",
+    "nav.graph": "グラフ",
+    "nav.settings": "設定",
   },
   en: {
     "app.title": "Rainbow Weight Log",
@@ -1102,6 +1107,11 @@ export const translations = {
     "streakReward.master": "Master",
     "streakReward.legend": "Legend",
     "streakReward.hint": "Record daily to earn the next badge!",
+    "nav.home": "Home",
+    "nav.search": "Search",
+    "nav.calendar": "Calendar",
+    "nav.graph": "Graph",
+    "nav.settings": "Settings",
   },
 };
 


### PR DESCRIPTION
## Summary
Implemented a fixed bottom navigation bar to enable mobile-friendly tab switching between different sections of the app (Home, Search, Calendar, Graph, and Settings). This replaces the previous single-column layout with a tab-based navigation system.

## Key Changes
- **Bottom Navigation UI**: Added a fixed bottom navigation bar with 5 navigation buttons, each with an icon and label
  - Includes glassmorphism effect with backdrop blur
  - Supports safe area insets for notched devices
  - Active state styling with color and scale animations
  - Touch-friendly with tap feedback (scale animation)

- **Tab-based Content System**: Refactored the layout to support multiple tabs
  - Introduced `activeTab` state variable to track current section
  - Wrapped each major content section (home, search, calendar, graph, settings) in separate columns with `data-tab` attributes
  - Content visibility controlled via inline styles based on `activeTab`
  - Changed grid layout from 2-column to single column to accommodate mobile-first design

- **Navigation Binding**: Added event listeners to bottom nav buttons
  - Clicking a nav button updates `activeTab` and re-renders the page
  - Automatically scrolls to top when switching tabs

- **Internationalization**: Added translation keys for all navigation labels
  - Japanese: ホーム, 検索, カレンダー, グラフ, 設定
  - English: Home, Search, Calendar, Graph, Settings

- **Mobile Responsiveness**: Updated print media query to hide bottom navigation on print

- **Layout Adjustments**: Increased app-shell bottom padding from 48px to 100px to prevent content overlap with fixed navigation

## Implementation Details
- Navigation uses semantic HTML with `role="navigation"` and `aria-label`
- SVG icons with responsive sizing and stroke-width adjustments
- Smooth transitions for color and transform properties
- `-webkit-tap-highlight-color: transparent` for cleaner mobile UX
- Z-index of 1000 ensures navigation stays above other content

https://claude.ai/code/session_0125j5eQ6uHpxtPwoGNgbAS8