### PR TITLE
Refactor bottom tab bar to 4‑item floating iOS‑style menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -3740,7 +3740,7 @@
 
       /* === SmartDiet-style Tab Layout === */
       .tab-layout {
-        padding-bottom: 80px !important;
+        padding-bottom: 118px !important;
       }
 
       .tab-page {
@@ -3751,18 +3751,20 @@
       /* Bottom Tab Bar */
       .bottom-tabs {
         position: fixed;
-        bottom: 0;
-        left: 0;
-        right: 0;
+        left: 14px;
+        right: 14px;
+        bottom: calc(10px + env(safe-area-inset-bottom, 0));
         display: grid;
-        grid-template-columns: repeat(5, 1fr);
+        grid-template-columns: repeat(4, 1fr);
         background: var(--surface-strong);
-        border-top: 1px solid var(--border);
+        border: 1px solid var(--border);
+        border-radius: 28px;
         backdrop-filter: blur(20px);
         -webkit-backdrop-filter: blur(20px);
+        box-shadow: 0 16px 28px rgba(0, 0, 0, 0.14);
         z-index: 1000;
-        padding: 4px 0;
-        padding-bottom: max(4px, env(safe-area-inset-bottom, 0));
+        padding: 8px;
+        gap: 6px;
       }
 
       .bottom-tab {
@@ -3770,21 +3772,23 @@
         flex-direction: column;
         align-items: center;
         justify-content: center;
-        gap: 2px;
-        padding: 8px 4px 6px;
-        min-height: 52px;
+        gap: 4px;
+        padding: 10px 4px 8px;
+        min-height: 58px;
+        border-radius: 20px;
         background: none;
         border: none;
         color: var(--muted);
-        font-size: 10px;
+        font-size: 11px;
         font-weight: 600;
         cursor: pointer;
-        transition: color 0.2s, transform 0.1s;
+        transition: color 0.2s, transform 0.1s, background-color 0.2s;
         -webkit-tap-highlight-color: transparent;
       }
 
       .bottom-tab.active {
-        color: var(--accent);
+        color: var(--text);
+        background: color-mix(in srgb, var(--accent) 22%, transparent);
       }
 
       .bottom-tab:active {
@@ -3797,8 +3801,8 @@
       }
 
       .bottom-tab-svg {
-        width: 22px;
-        height: 22px;
+        width: 21px;
+        height: 21px;
       }
 
       .bottom-tab-label {

--- a/src/app.js
+++ b/src/app.js
@@ -813,20 +813,16 @@ function render() {
       <!-- Bottom Tab Bar -->
       <nav class="bottom-tabs" role="tablist" aria-label="Navigation">
         <button type="button" class="bottom-tab ${activeTab === "input" ? "active" : ""}" data-tab="input" role="tab" aria-selected="${activeTab === "input"}">
-          <svg class="bottom-tab-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 4v16m8-8H4"/></svg>
+          <svg class="bottom-tab-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.1 2.1 0 1 1 3 3L7 19l-4 1 1-4Z"/></svg>
           <span class="bottom-tab-label">${t("tab.input")}</span>
-        </button>
-        <button type="button" class="bottom-tab ${activeTab === "graph" ? "active" : ""}" data-tab="graph" role="tab" aria-selected="${activeTab === "graph"}">
-          <svg class="bottom-tab-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="22 12 18 12 15 21 9 3 6 12 2 12"/></svg>
-          <span class="bottom-tab-label">${t("tab.graph")}</span>
         </button>
         <button type="button" class="bottom-tab ${activeTab === "calendar" ? "active" : ""}" data-tab="calendar" role="tab" aria-selected="${activeTab === "calendar"}">
           <svg class="bottom-tab-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><rect x="3" y="4" width="18" height="18" rx="2" ry="2"/><line x1="16" y1="2" x2="16" y2="6"/><line x1="8" y1="2" x2="8" y2="6"/><line x1="3" y1="10" x2="21" y2="10"/></svg>
           <span class="bottom-tab-label">${t("tab.calendar")}</span>
         </button>
-        <button type="button" class="bottom-tab ${activeTab === "records" ? "active" : ""}" data-tab="records" role="tab" aria-selected="${activeTab === "records"}">
-          <svg class="bottom-tab-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><line x1="8" y1="6" x2="21" y2="6"/><line x1="8" y1="12" x2="21" y2="12"/><line x1="8" y1="18" x2="21" y2="18"/><line x1="3" y1="6" x2="3.01" y2="6"/><line x1="3" y1="12" x2="3.01" y2="12"/><line x1="3" y1="18" x2="3.01" y2="18"/></svg>
-          <span class="bottom-tab-label">${t("tab.records")}</span>
+        <button type="button" class="bottom-tab ${activeTab === "graph" ? "active" : ""}" data-tab="graph" role="tab" aria-selected="${activeTab === "graph"}">
+          <svg class="bottom-tab-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><polyline points="3 17 9 11 13 15 21 7"/><polyline points="14 7 21 7 21 14"/></svg>
+          <span class="bottom-tab-label">${t("tab.graph")}</span>
         </button>
         <button type="button" class="bottom-tab ${activeTab === "settings" ? "active" : ""}" data-tab="settings" role="tab" aria-selected="${activeTab === "settings"}">
           <svg class="bottom-tab-svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="3"/><path d="M19.4 15a1.65 1.65 0 00.33 1.82l.06.06a2 2 0 010 2.83 2 2 0 01-2.83 0l-.06-.06a1.65 1.65 0 00-1.82-.33 1.65 1.65 0 00-1 1.51V21a2 2 0 01-4 0v-.09A1.65 1.65 0 009 19.4a1.65 1.65 0 00-1.82.33l-.06.06a2 2 0 01-2.83-2.83l.06-.06A1.65 1.65 0 004.68 15a1.65 1.65 0 00-1.51-1H3a2 2 0 010-4h.09A1.65 1.65 0 004.6 9a1.65 1.65 0 00-.33-1.82l-.06-.06a2 2 0 012.83-2.83l.06.06A1.65 1.65 0 009 4.68a1.65 1.65 0 001-1.51V3a2 2 0 014 0v.09a1.65 1.65 0 001 1.51 1.65 1.65 0 001.82-.33l.06-.06a2 2 0 012.83 2.83l-.06.06A1.65 1.65 0 0019.4 9a1.65 1.65 0 001.51 1H21a2 2 0 010 4h-.09a1.65 1.65 0 00-1.51 1z"/></svg>


### PR DESCRIPTION
### Motivation
- Update the bottom navigation to match the provided iOS-style screenshot: compact floating capsule with 4 items instead of the previous 5-item layout. 
- Improve mobile ergonomics by moving to a rounded floating container and respecting safe-area insets so the Settings tab is reachable and visually prominent.

### Description
- Reworked bottom tab markup in `src/app.js` to a 4-item order: `input`, `calendar`, `graph`, `settings`, and removed the `records` tab from the bottom bar. 
- Replaced the `input` and `graph` SVG icons with new simplified icons and adjusted tab ordering to match the design. 
- Updated CSS in `index.html` to make the bar a rounded, floating capsule (changed to `grid-template-columns: repeat(4, 1fr)`, added border, radius, shadow, gap, padding and safe-area aware `bottom` offset). 
- Adjusted tab sizing/spacing and active state to use an active-pill highlight (`background: color-mix(...)`) and tuned font/icon sizes for consistent appearance.

### Testing
- Ran unit tests with `npm test` which passed (`test/logic.test.js`: 1191 tests). 
- Ran full check with `npm run check` (runs `npm test` + syntax checks) and it completed successfully. 
- Built the web bundle with `npm run prepare:web` and served the `web` output; a Playwright script navigated to the app and captured a screenshot of the settings screen with the updated bottom menu (`artifacts/bottom-menu-settings.png`).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b5a1383dec8324ade6378701b86528)